### PR TITLE
Fix python3 compatibility with "2to3 styler.py"

### DIFF
--- a/CR1/styler.py
+++ b/CR1/styler.py
@@ -90,9 +90,9 @@ def styler(func):
     ## print the arguments, for debugging
     if kwargs.get('verbose', False):
       from pprint import pprint
-      print "Arguments were:"
-      print args
-      print pprint(kwargs)
+      print("Arguments were:")
+      print(args)
+      print(pprint(kwargs))
 
 
     figwidth, figheight = kwargs.get('figsize', (default_figwidth, default_figheight_factor))
@@ -154,7 +154,7 @@ def styler(func):
               ax.yaxis.get_major_formatter().set_useOffset(False)
               ax.xaxis.get_major_formatter().set_useOffset(False)
             except AttributeError:
-              print 'Cannot remove offset from axis, maybe using log axis?'
+              print('Cannot remove offset from axis, maybe using log axis?')
 
             try:
               if ax.is_colorbar and format_cbar:
@@ -172,7 +172,7 @@ def styler(func):
       if save is None:
         fig.show()
       else:
-        assert type(save) in (str, unicode)
+        assert type(save) in (str, str)
         fig.savefig(save, dpi=fig.dpi)
 
   return inner


### PR DESCRIPTION
If I was at the code review I would probably have mentioned this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/iastro-pt/codereviewclub/3)
<!-- Reviewable:end -->
